### PR TITLE
Fix optional callback arities

### DIFF
--- a/lib/xdr/type/base.ex
+++ b/lib/xdr/type/base.ex
@@ -32,5 +32,5 @@ defmodule XDR.Type.Base do
   """
   @callback decode(xdr :: xdr) :: {:ok, {native :: t, rest :: xdr}} | {:error, reason :: error}
 
-  @optional_callbacks [length: 1, new: 0]
+  @optional_callbacks [length: 0, new: 1]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule XDR.Mixfile do
   use Mix.Project
 
   @name    :xdr
-  @version "0.1.0"
+  @version "0.1.1"
 
   @deps [
     {:math, "~> 0.3.0"},


### PR DESCRIPTION
When compiling xdr in a project after getting it from hex I ran into the following error:

```
== Compilation error in file lib/xdr/type/base.ex ==
** (CompileError) lib/xdr/type/base.ex:1: unknown callback length/1 given as optional callback
    (stdlib) lists.erl:1263: :lists.foldl/3
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
could not compile dependency :xdr, "mix compile" failed. You can recompile this dependency with "mix deps.compile xdr", update it with "mix deps.update xdr" or clean it with "mix deps.clean xdr"
```

I changed the arities in the optional_callback attribute to match those of the callbacks