### PR TITLE
Use signed integers for enums instead of unsigned integers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ erl_crash.dump
 
 # misc
 .DS_Store
+
+# Language Server
+.elixir_ls


### PR DESCRIPTION
[Some of the enums in the stellar xdr definitions have negative values in the enums](https://github.com/stellar/js-stellar-base/blob/master/xdr/Stellar-transaction.x#L370). I was getting an error about "all enum values must be numbers" when I tried to use negative numbers.

This PR updates that check to look for negative number AST and also makes it so Enum uses Int instead of Uint to decode and encode values: